### PR TITLE
Fixed hidden footer

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -364,7 +364,7 @@ nav a:hover {
   gap: 3%;
   justify-content: center;
   margin-bottom: 0;
-  opacity: 40%;
+  opacity: 0.4;
   white-space: nowrap;
 }
 
@@ -523,7 +523,7 @@ nav a:hover {
 
 .footer__header {
   font-weight: 700;
-  opacity: 90%;
+  opacity: 0.9;
   white-space: nowrap;
 }
 
@@ -534,5 +534,5 @@ nav a:hover {
 }
 
 .footer__list a:hover {
-  opacity: 50%;
+  opacity: 0.5;
 }


### PR DESCRIPTION
Fixed issue #2

This was caused because of the opacity property. The values passed should be between 0 - 1.  Most modern browsers (e.g., Chrome, Firefox, Edge) are forgiving during local development. When they encounter an invalid CSS value like opacity: 90%, they may interpret it as a valid fallback, which is why it worked as expected locally.